### PR TITLE
Made virtual int _id() function return a const

### DIFF
--- a/src/main/cpp/algorithms/datastructures/stack/Stack.h
+++ b/src/main/cpp/algorithms/datastructures/stack/Stack.h
@@ -42,7 +42,7 @@ public:
   virtual ~Stack() {}
 
   // return the ID the stack implementation
-  virtual int id() { return id_; }
+  virtual int id() const { return id_; }
 
   // return the number of elements in the stack
   virtual int size() = 0;


### PR DESCRIPTION
Since the function does no mutation to the _id variable it returns from private, it is a good practice in c++ to make it return const